### PR TITLE
requirements: update 'urllib3'

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,4 +45,4 @@ pycparser==2.19
 rsa==4.0
 six==1.12.0
 uritemplate==3.0.0
-urllib3==1.24.1
+urllib3==1.24.3


### PR DESCRIPTION
Closes #11.

Fix security vulnerabilities:
- [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324):
  The urllib3 library before 1.24.2 for Python mishandles certain cases where
  the desired set of CA certificates is different from the OS store of CA
  certificates, which results in SSL connections succeeding in situations where
  a verification failure is the correct outcome. This is related to use of the
  `ssl_context`, `ca_certs`, or `ca_certs_dir` argument.
- [CVE-2019-9740](https://nvd.nist.gov/vuln/detail/CVE-2019-9740):
  An issue was discovered in urllib2 in Python 2.x through 2.7.16 and urllib in
  Python 3.x through 3.7.2. CRLF injection is possible if the attacker controls
  a url parameter, as demonstrated by the first argument to
  `urllib.request.urlopen` with `\r\n` followed by an HTTP header or a Redis
  command.

Changelog:
- 1.24.3 (2019-05-01)
  https://github.com/urllib3/urllib3/blob/1.24.3/CHANGES.rst#1243-2019-05-01

Code diff:
https://github.com/urllib3/urllib3/compare/1.24.1...1.24.3