### PR TITLE
config: Verify Python dependency compatibility in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,12 @@ jobs:
             pip install -r requirements/test.txt
 
       - run:
+          name: Check Dependencies
+          command: |
+            . venv/bin/activate
+            pip check
+
+      - run:
           name: run tests
           command: |
             . venv/bin/activate
@@ -72,6 +78,12 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
             pip install -r requirements/release.txt
+
+      - run:
+          name: Check Dependencies
+          command: |
+            . venv/bin/activate
+            pip check
 
       - run:
           name: make dist


### PR DESCRIPTION
We need to use `pip check` because it returns a non-zero exit status
when there are dependency version conflicts. `pip install` just prints a
warning, which does not cause a CI failure.

See also: https://github.com/pypa/pip/issues/6200