### PR TITLE
Release v0.1.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.4
 commit = True
 tag = True
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,12 @@ jobs:
             pip install -r requirements/test.txt
 
       - run:
+          name: Check Dependencies
+          command: |
+            . venv/bin/activate
+            pip check
+
+      - run:
           name: run tests
           command: |
             . venv/bin/activate
@@ -72,6 +78,12 @@ jobs:
             pip install --upgrade pip
             pip install --upgrade setuptools wheel
             pip install -r requirements/release.txt
+
+      - run:
+          name: Check Dependencies
+          command: |
+            . venv/bin/activate
+            pip check
 
       - run:
           name: make dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,22 @@
 #
 version: "2.1"
 
+# -----BEGIN Environment Variables-----
+
+# Environment variables required for deployment:
+#
+# - PYPI_PASSWORD := PyPI password or API token.
+# - PYPI_USERNAME := PyPI username. For API tokens, use "__token__".
+# - TWINE_NON_INTERACTIVE := Do not interactively prompt for credentials if they are missing.
+# - TWINE_REPOSITORY_URL := The repository (package index) URL to register the package to.
+
+# x-deploy-environment := Deployment environment variables
+x-deploy-environment: &x-deploy-environment
+  TWINE_NON_INTERACTIVE: "true"
+  TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
+
+# -----END Environment Variables-----
+
 jobs:
   test:
     parameters:
@@ -95,6 +111,35 @@ jobs:
           path: dist
           destination: dist
 
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - dist
+            - venv
+
+  deploy:
+    docker:
+      - image: python:3.7.2
+        environment:
+          <<: *x-deploy-environment
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - attach_workspace:
+          at: ~/repo
+
+      - deploy:
+          name: Upload Artifacts to Repository
+          command: |
+            . venv/bin/activate
+
+            make upload-release \
+              TWINE_USERNAME="${PYPI_USERNAME:?}" \
+              TWINE_PASSWORD="${PYPI_PASSWORD:?}"
+
 workflows:
   version: 2
   ci:
@@ -107,3 +152,10 @@ workflows:
                 - "3.8.2" # Ubuntu 20.04 LTS
                 - "3.8.3" # Latest version
       - dist
+      - deploy:
+          requires:
+            - dist
+          filters:
+            branches:
+              only:
+                - master

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# GitHub Dependabot Configuration
+#
+# Documentation:
+#   https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+      time: "08:30"
+      timezone: America/Santiago
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,20 @@ History
 unreleased (YYYY-MM-DD)
 +++++++++++++++++++++++
 
+0.1.4 (2020-09-15)
+++++++++++++++++++
+
+* (PR #26, 2020-09-15) build(deps): bump uritemplate from 3.0.0 to 3.0.1
+* (PR #39, 2020-09-15) config: Add PyPI package uploading to CI
+* (PR #23, 2020-09-15) build(deps): bump twine from 1.13.0 to 3.2.0
+* (PR #38, 2020-09-15) build(deps): bump setuptools from 41.0.1 to 50.3.0
+* (PR #27, 2020-07-09) config: Verify Python dependency compatibility in CI
+* (PR #28, 2020-07-09) requirements: update dependencies of 'flake8'
+* (PR #24, 2020-07-08) build(deps): bump flake8 from 3.7.8 to 3.8.3
+* (PR #22, 2020-07-07) config: Add configuration for GitHub Dependabot
+* (PR #21, 2020-06-18) Update readme
+* (PR #20, 2020-06-09) requirements: update 'httplib2'
+
 0.1.3 (2020-06-08)
 ++++++++++++++++++
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# fyndata/gcp-utils-python
+FD Google Cloud Platform Utilities for Python
+================================================
 
 [![PyPI package version](https://img.shields.io/pypi/v/fyndata-gcp-utils.svg)](https://pypi.org/project/fyndata-gcp-utils/)
 [![Python versions](https://img.shields.io/pypi/pyversions/fyndata-gcp-utils.svg)](https://pypi.org/project/fyndata-gcp-utils/)
 [![License](https://img.shields.io/pypi/l/fyndata-gcp-utils.svg)](https://pypi.org/project/fyndata-gcp-utils/)
 
-Fyndata's Python library of Google Cloud Platform (GCP) utils.
+FD's Python library of Google Cloud Platform (GCP) utils.
 
 - Python package: `fd_gcp`
 - Python distribution package name: `fyndata-gcp-utils`
@@ -15,12 +16,11 @@ Fyndata's Python library of Google Cloud Platform (GCP) utils.
 
 | branch  | build |
 | ------- | ----- |
-| master  | [![CircleCI](https://circleci.com/gh/fyndata/gcp-utils-python/tree/master.svg?style=shield)](https://circleci.com/gh/fyndata/gcp-utils-python/tree/master) |
-| develop | [![CircleCI](https://circleci.com/gh/fyndata/gcp-utils-python/tree/develop.svg?style=shield)](https://circleci.com/gh/fyndata/gcp-utils-python/tree/develop) |
+| master  | [![CircleCI](https://circleci.com/gh/fyntex/gcp-utils-python/tree/master.svg?style=svg)](https://circleci.com/gh/fyntex/gcp-utils-python/tree/master) |
+| develop | [![CircleCI](https://circleci.com/gh/fyntex/gcp-utils-python/tree/develop.svg?style=svg)](https://circleci.com/gh/fyntex/gcp-utils-python/tree/develop) |
 
 
 ## Supported Python versions
 
 Only Python 3.7 and 3.8. Python 3.6 and below will not work because we use some features introduced
-in Python 3.7. In the future, for real multiversion support we need to set up `tox`
-(see [tox.ini](tox.ini) and [setup.py](setup.py)).
+in Python 3.7.

--- a/docs/project-maintenance.rst
+++ b/docs/project-maintenance.rst
@@ -92,19 +92,7 @@ Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversi
 
   * "Publish release".
 
-4) Publish to PyPI
-+++++++++++++++++++
-
-(local workstation)
-
-Run::
-
-    make upload-release
-    make -s clean
-
-Check out the `project's page at PyPI <https://pypi.org/project/fyndata-gcp-utils/>`_.
-
-5) Update ``develop``
+4) Update ``develop``
 +++++++++++++++++++
 
 (local workstation)

--- a/fd_gcp/__init__.py
+++ b/fd_gcp/__init__.py
@@ -30,4 +30,4 @@ analogy of AWS' concept of *Amazon Resource Name* (ARN): *Google Resource Name*
 """
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -44,5 +44,5 @@ pyasn1-modules==0.2.5
 pycparser==2.19
 rsa==4.0
 six==1.15.0
-uritemplate==3.0.0
+uritemplate==3.0.1
 urllib3==1.25.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 google-auth-httplib2==0.0.3
-httplib2==0.13.0
+httplib2==0.18.1
 idna==2.8
 pyasn1==0.4.5
 pyasn1-modules==0.2.5

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -5,7 +5,7 @@
 # Required packages:
 bumpversion==0.5.3
 setuptools==50.3.0
-twine==1.13.0
+twine==3.2.0
 wheel==0.33.4
 
 # Packages dependencies:

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -4,7 +4,7 @@
 
 # Required packages:
 bumpversion==0.5.3
-setuptools==41.0.1
+setuptools==50.3.0
 twine==1.13.0
 wheel==0.33.4
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -44,8 +44,8 @@ mypy-extensions==0.4.1
 packaging==19.0
 pluggy==0.13.1
 py==1.8.0
-pycodestyle==2.5.0
-pyflakes==2.1.1
+pycodestyle==2.6.0
+pyflakes==2.2.0
 pyparsing==2.4.0
 six==1.15.0
 toml==0.10.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 # Required packages:
 codecov==2.0.15
 coverage==4.5.3
-flake8==3.7.8
+flake8==3.8.3
 mypy==0.711
 #requests-mock==1.5.2
 tox==3.15.2


### PR DESCRIPTION
- (PR #26, 2020-09-15) build(deps): bump uritemplate from 3.0.0 to 3.0.1
- (PR #39, 2020-09-15) config: Add PyPI package uploading to CI
- (PR #23, 2020-09-15) build(deps): bump twine from 1.13.0 to 3.2.0
- (PR #38, 2020-09-15) build(deps): bump setuptools from 41.0.1 to 50.3.0
- (PR #27, 2020-07-09) config: Verify Python dependency compatibility in CI
- (PR #28, 2020-07-09) requirements: update dependencies of 'flake8'
- (PR #24, 2020-07-08) build(deps): bump flake8 from 3.7.8 to 3.8.3
- (PR #22, 2020-07-07) config: Add configuration for GitHub Dependabot
- (PR #21, 2020-06-18) Update readme
- (PR #20, 2020-06-09) requirements: update 'httplib2'