### PR TITLE
requirements: Update dependency graph of 'idna'

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,6 @@ requests==2.25.1
 #       - asn1crypto
 #       - cffi
 #           - pycparser
-#       - idna
 #       - six
 #   - google-api-python-client:
 #       - google-auth


### PR DESCRIPTION
- Starting from `cryptography` v2.5, `idna` stopped being a required
  dependency.

  > BACKWARDS INCOMPATIBLE: U-label strings were deprecated in version
  > 2.1, but this version removes the default `idna` dependency as well.
  > If you still need this deprecated path please install cryptography
  > with the `idna` extra: `pip install cryptography[idna]`.

  Source: https://cryptography.io/en/3.4.5/changelog.html#v2-5.
- `requests` still requires `idna`.

-----

Fixes: https://github.com/fyntex/gcp-utils-python/pull/64#issuecomment-780015701.